### PR TITLE
8048 panic in drm_gem_unmap with Xorg 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,16 @@
 #
 ONBLD_TOOLS=/opt/onbld
 
+# Do both debug and non-debug build in uts, in that order, so
+# (a) we know the debug code builds, and (b) install non-debug.
 install: FRC
+	$(ONBLD_TOOLS)/bin/bldenv -d myenv.sh \
+	"cd usr/src/uts ; make install"
 	$(ONBLD_TOOLS)/bin/bldenv myenv.sh \
+	"cd usr/src ; make install"
+
+debug: FRC
+	$(ONBLD_TOOLS)/bin/bldenv -d myenv.sh \
 	"cd usr/src ; make install"
 
 clean: FRC

--- a/usr/src/common/libdrm/Makefile.drm
+++ b/usr/src/common/libdrm/Makefile.drm
@@ -39,5 +39,6 @@ CPPFLAGS +=	-I$(SRC)/uts/common \
 		-I$(SRC)/uts/common/drm \
 		-I$(LIBDRM_CMN_DIR)/include/drm
 
-# The libdrm code has lots of parentheses warnings.  Suppress.
+# The libdrm code has lots of warnings.  Just suppress.
 CERRWARN +=	-_gcc=-Wno-parentheses
+CERRWARN +=	-_gcc=-Wno-unused-function

--- a/usr/src/uts/common/io/drm/drm_gem.c
+++ b/usr/src/uts/common/io/drm/drm_gem.c
@@ -759,12 +759,16 @@ drm_gem_create_mmap_offset(struct drm_gem_object *obj)
 void
 drm_gem_mmap(struct drm_gem_object *obj, pfn_t pfn)
 {
+	ASSERT(obj->gtt_map_kaddr != NULL);
+	/* Does hat_devload() */
 	gfxp_load_kernel_space(pfn, obj->real_size, GFXP_MEMORY_WRITECOMBINED, obj->gtt_map_kaddr);
 }
 
 void
 drm_gem_release_mmap(struct drm_gem_object *obj)
 {
+	ASSERT(obj->gtt_map_kaddr != NULL);
+	/* Does hat_unload() */
 	gfxp_unload_kernel_space(obj->gtt_map_kaddr, obj->real_size);
 }
 

--- a/usr/src/uts/intel/io/i915/i915_dma.c
+++ b/usr/src/uts/intel/io/i915/i915_dma.c
@@ -1510,7 +1510,6 @@ out_mtrrfree:
 out_rmmap:
 	drm_ioremapfree(dev_priv->regs);
 put_bridge:
-free_priv:
 	kfree(dev_priv, sizeof(struct drm_i915_private));
 	return ret;
 }
@@ -1573,7 +1572,7 @@ int i915_driver_unload(struct drm_device *dev)
 			i915_free_hws(dev);
 		i915_gem_lastclose(dev);
 		if (dev_priv->gtt.scratch_page)
-			teardown_scratch_page(dev);
+			i915_teardown_scratch_page(dev);
 		if (dev_priv->fbcon_obj != NULL) {
 			i915_gem_free_object(&dev_priv->fbcon_obj->base);
 			dev_priv->fbcon_obj = NULL;

--- a/usr/src/uts/intel/io/i915/i915_drv.c
+++ b/usr/src/uts/intel/io/i915/i915_drv.c
@@ -1098,7 +1098,7 @@ i915_quiesce(dev_info_t *dip)
 		i915_gem_lastclose(dev);
 
 		if (dev_priv->gtt.scratch_page)
-			teardown_scratch_page(dev);
+			i915_teardown_scratch_page(dev);
 
 		if (MDB_TRACK_ENABLE) {
 			struct batch_info_list *r_list, *list_temp;

--- a/usr/src/uts/intel/io/i915/i915_drv.h
+++ b/usr/src/uts/intel/io/i915/i915_drv.h
@@ -1837,8 +1837,8 @@ void i915_gem_gtt_finish_object(struct drm_i915_gem_object *obj);
 int i915_gem_init_global_gtt(struct drm_device *dev);
 void i915_gem_setup_global_gtt(struct drm_device *dev, unsigned long start,
 			       unsigned long mappable_end, unsigned long end);
-int setup_scratch_page(struct drm_device *dev);
-void teardown_scratch_page(struct drm_device *dev);
+int i915_setup_scratch_page(struct drm_device *dev);
+void i915_teardown_scratch_page(struct drm_device *dev);
 int i915_gem_gtt_init(struct drm_device *dev);
 void intel_rw_gtt(struct drm_device *dev, size_t size,
 		uint32_t gtt_offset, void *gttp, uint32_t type);

--- a/usr/src/uts/intel/io/i915/i915_gem.c
+++ b/usr/src/uts/intel/io/i915/i915_gem.c
@@ -3625,7 +3625,7 @@ int i915_gem_init(struct drm_device *dev)
 		if (!dev_priv->fbcon_obj) {
 			DRM_ERROR("failed to allocate framebuffer");
 			mutex_unlock(&dev->struct_mutex);
-			teardown_scratch_page(dev);
+			i915_teardown_scratch_page(dev);
 			return (-ENOMEM);
 		}
 
@@ -3637,7 +3637,7 @@ int i915_gem_init(struct drm_device *dev)
 		if (ret) {
 			DRM_ERROR("failed to pin fb ret %d", ret);
 			mutex_unlock(&dev->struct_mutex);
-			teardown_scratch_page(dev);
+			i915_teardown_scratch_page(dev);
 			i915_gem_free_object(&dev_priv->fbcon_obj->base);
 			return ret;
 		}

--- a/usr/src/uts/intel/io/i915/i915_gem_gtt.c
+++ b/usr/src/uts/intel/io/i915/i915_gem_gtt.c
@@ -698,7 +698,7 @@ int i915_gem_init_global_gtt(struct drm_device *dev)
 	}
 	i915_gem_setup_global_gtt(dev, 0, mappable_size, gtt_size);
 
-	ret = setup_scratch_page(dev);
+	ret = i915_setup_scratch_page(dev);
 	if (ret)
 		return ret;
 
@@ -713,13 +713,20 @@ int i915_gem_init_global_gtt(struct drm_device *dev)
 	return 0;
 }
 
-int setup_scratch_page(struct drm_device *dev)
+/*
+ * Just to be safe against memory overwrite, let's allocate this with
+ * sizeof drm_i915_gem_object, even though we don't use the i915 part.
+ * This way, all i915 GEM objects are the same size.
+ */
+int
+i915_setup_scratch_page(struct drm_device *dev)
 {
 	struct drm_i915_private *dev_priv = dev->dev_private;
 	int gen;
 
 	/* setup scratch page */
-	dev_priv->gtt.scratch_page = kzalloc(sizeof(struct drm_gem_object), GFP_KERNEL);
+	dev_priv->gtt.scratch_page =
+	    kzalloc(sizeof(struct drm_i915_gem_object), GFP_KERNEL);
 	if (dev_priv->gtt.scratch_page == NULL) {
 		DRM_ERROR("setup_scratch_page: gem object init failed");
 		return (-ENOMEM);
@@ -731,7 +738,8 @@ int setup_scratch_page(struct drm_device *dev)
 		gen = INTEL_INFO(dev)->gen * 10;
 
 	if (drm_gem_object_init(dev, dev_priv->gtt.scratch_page, DRM_PAGE_SIZE, gen) != 0) {
-		kmem_free(dev_priv->gtt.scratch_page, sizeof (struct drm_gem_object));
+		kmem_free(dev_priv->gtt.scratch_page,
+		    sizeof (struct drm_i915_gem_object));
 		dev_priv->gtt.scratch_page = NULL;
 		DRM_ERROR("setup_scratch_page: gem object init failed");
 		return (-ENOMEM);
@@ -741,7 +749,8 @@ int setup_scratch_page(struct drm_device *dev)
 	return 0;
 }
 
-void teardown_scratch_page(struct drm_device *dev)
+void
+i915_teardown_scratch_page(struct drm_device *dev)
 {
 	struct drm_i915_private *dev_priv = dev->dev_private;
 
@@ -749,7 +758,9 @@ void teardown_scratch_page(struct drm_device *dev)
 		return;
 
 	drm_gem_object_release(dev_priv->gtt.scratch_page);
-	kmem_free(dev_priv->gtt.scratch_page, sizeof (struct drm_gem_object));
+	kmem_free(dev_priv->gtt.scratch_page,
+	    sizeof (struct drm_i915_gem_object));
+	dev_priv->gtt.scratch_page = NULL;
 }
 
 static inline unsigned int gen6_get_total_gtt_size(u16 snb_gmch_ctl)

--- a/usr/src/uts/intel/io/i915/intel_display.c
+++ b/usr/src/uts/intel/io/i915/intel_display.c
@@ -7619,7 +7619,6 @@ cleanup_pending:
 	drm_gem_object_unreference(&obj->base);
 	mutex_unlock(&dev->struct_mutex);
 
-cleanup:
 	spin_lock_irqsave(&dev->event_lock, flags);
 	intel_crtc->unpin_work = NULL;
 	spin_unlock_irqrestore(&dev->event_lock, flags);

--- a/usr/src/uts/intel/io/i915/intel_fb.c
+++ b/usr/src/uts/intel/io/i915/intel_fb.c
@@ -92,7 +92,6 @@ static int intelfb_create(struct drm_fb_helper *helper,
 
 out_unpin:
 	i915_gem_object_unpin(obj);
-out_unref:
 	drm_gem_object_unreference(&obj->base);
 	mutex_unlock(&dev->struct_mutex);
 out:


### PR DESCRIPTION
Turns out the devmap callbacks for GEM objects needed a bunch of work.
Found a few other oddities about GEM objects along the way...

Tested with Xorg 1.18 -- login/logout no longer crash.
